### PR TITLE
Declare least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   basic-pathways:
     runs-on: ubuntu-latest

--- a/.github/workflows/cpu-smoke.yml
+++ b/.github/workflows/cpu-smoke.yml
@@ -3,6 +3,9 @@ name: cpu-smoke
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   public-tiny-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -12,6 +12,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- declare `contents: read` for CI, CPU smoke, and release workflows
- preserve the existing explicit Pages deployment permissions
- resolve the initial CodeQL workflow-permission findings without changing effective access

## Validation

- `actionlint .github/workflows/*.yml`
- `pytest -q tests/test_public_surface.py tests/test_release_metadata.py` (51 passed)
- `python scripts/ci_basic_sanity.py`
- `python scripts/check_release_metadata.py --release`