### PR TITLE
Announce upcoming OpenWAM research release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ share the same trainer and visual stack.
 > benchmark runs use separately provisioned datasets and checkpoints described
 > by the [artifact contract](docs/artifacts.md).
 
+## Upcoming Research Release
+
+Detailed evaluation results, trained model checkpoints, datasets, and the
+OpenWAM research paper are being prepared for public release and will be
+available very soon. Canonical links and integrity metadata will be added to
+the [artifact documentation](docs/artifacts.md) as each resource is published.
+
 ## Research Scope
 
 OpenWAM provides:


### PR DESCRIPTION
## Summary

Adds a concise README section announcing that detailed evaluations, trained checkpoints, datasets, and the OpenWAM paper will be released very soon. The note points readers to the artifact documentation for canonical links and integrity metadata.

## Validation

- release metadata validation
- public documentation staging: zero broken links and zero private-path leaks