### PR TITLE
Promote validated OpenWAM staging changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,11 @@
 ## Summary
 
+<!-- public-summary:start -->
+<!-- Copied into public release/promotion notes. Keep this section and the title public-safe. -->
 - What changed:
 - Why it changed:
 - User/developer impact:
+<!-- public-summary:end -->
 
 ## Change Type
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,72 @@
+name: publish-pypi
+
+# Neither staging promotion nor a main push publishes a package.
+on:
+  workflow_dispatch:
+    inputs:
+      index:
+        description: Package index (run against the reviewed release tag)
+        required: true
+        type: choice
+        default: testpypi
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ inputs.index }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify-ref:
+    if: github.repository == 'OpenWAM/OpenWAM' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Require a version-matched tag from production main
+        env:
+          RELEASE_REF: ${{ github.ref }}
+        run: |
+          git merge-base --is-ancestor HEAD origin/main
+          python scripts/build_pypi_distributions.py --check-tag "$RELEASE_REF"
+
+  checks:
+    needs: verify-ref
+    uses: ./.github/workflows/release-checks.yml
+    with:
+      release: true
+
+  publish:
+    needs: checks
+    runs-on: ubuntu-latest
+    # Configure required reviewers and v* tag restrictions on both environments.
+    environment:
+      name: ${{ inputs.index }}
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-distributions
+          path: dist
+      - name: Publish canonical OpenWAM first
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          repository-url: ${{ inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          packages-dir: dist/core/
+          skip-existing: true
+      - name: Publish official installation aliases
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          repository-url: ${{ inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          packages-dir: dist/aliases/
+          skip-existing: true

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -1,6 +1,23 @@
 name: release-checks
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/*pypi*'
+      - '.github/workflows/release-checks.yml'
+      - 'scripts/*pypi*'
+      - 'scripts/check_release_metadata.py'
+      - 'tests/test_pypi_distributions.py'
+      - 'tests/test_release_metadata.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'README.md'
+      - 'docs/release.md'
+  workflow_call:
+    inputs:
+      release:
+        required: true
+        type: boolean
   workflow_dispatch:
     inputs:
       release:
@@ -16,18 +33,29 @@ permissions:
   contents: read
 
 jobs:
-  package:
+  dependency-audit:
+    name: release-dependency-audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Audit frozen full environment
+        run: uv run --frozen --group audit python scripts/check_dependency_audit.py
+
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install packaging tools
-        run: python -m pip install --upgrade build twine PyYAML
+        run: python -m pip install 'build>=1.2,<2' 'twine>=6' 'tomli-w>=1,<2' PyYAML pytest packaging
       - name: Check release metadata
         env:
           OPEN_WAM_FINAL_RELEASE: ${{ github.event_name == 'push' || inputs.release }}
@@ -37,11 +65,25 @@ jobs:
           else
             python scripts/check_release_metadata.py
           fi
-      - name: Audit frozen full environment
-        run: uv run --frozen --group audit python scripts/check_dependency_audit.py
-      - name: Build source and wheel distributions
-        run: python -m build
+      - name: Build canonical and alias distributions
+        run: python scripts/build_pypi_distributions.py --out-dir dist
       - name: Validate distributions
         run: |
-          python scripts/check_release_metadata.py --dist-dir dist
-          python -m twine check dist/*
+          python scripts/check_release_metadata.py --dist-dir dist/core
+          python scripts/check_release_metadata.py --dist-dir dist/aliases
+          python -m twine check --strict dist/core/* dist/aliases/*
+      - name: Prepare offline minimal installation dependencies
+        run: |
+          python -m pip download --only-binary=:all: --dest dist/dependencies dist/core/*.whl
+      - name: Exercise fresh canonical and alias installations
+        env:
+          OPENWAM_DISTRIBUTIONS_DIR: ${{ github.workspace }}/dist
+        run: python -m pytest -q tests/test_pypi_distributions.py tests/test_release_metadata.py
+      - name: Retain the tested distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-distributions
+          path: |
+            dist/core/
+            dist/aliases/
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
   <a href="https://github.com/OpenWAM/OpenWAM/actions/workflows/ci.yml"><img src="https://github.com/OpenWAM/OpenWAM/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://openwam.github.io/OpenWAM/"><img src="https://img.shields.io/badge/docs-online-blue.svg" alt="Documentation"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg" alt="Python 3.11 or 3.12"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License: AGPL v3"></a>
+  <a href="https://github.com/OpenWAM/OpenWAM/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License: AGPL v3"></a>
 </p>
 
 <p align="center">
   <a href="https://openwam.github.io/OpenWAM/">Documentation</a> &middot;
-  <a href="docs/quickstart.md">Quickstart</a> &middot;
-  <a href="docs/policy_architectures.md">Methods</a> &middot;
-  <a href="docs/running_experiments.md">Training and evaluation</a> &middot;
-  <a href="docs/extension_sdk.md">Extension SDK</a> &middot;
+  <a href="https://github.com/OpenWAM/OpenWAM/blob/main/docs/quickstart.md">Quickstart</a> &middot;
+  <a href="https://github.com/OpenWAM/OpenWAM/blob/main/docs/policy_architectures.md">Methods</a> &middot;
+  <a href="https://github.com/OpenWAM/OpenWAM/blob/main/docs/running_experiments.md">Training and evaluation</a> &middot;
+  <a href="https://github.com/OpenWAM/OpenWAM/blob/main/docs/extension_sdk.md">Extension SDK</a> &middot;
   <a href="#citation">Citation</a>
 </p>
 
@@ -24,11 +24,11 @@
 </p>
 
 <p align="center">
-  <a href="https://www.stanford.edu/"><img src="docs/assets/affiliations/stanford-wordmark.png" alt="Stanford University" height="20" valign="middle"></a>
+  <a href="https://www.stanford.edu/"><img src="https://raw.githubusercontent.com/OpenWAM/OpenWAM/main/docs/assets/affiliations/stanford-wordmark.png" alt="Stanford University" height="20" valign="middle"></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://ai.stanford.edu/"><img src="docs/assets/affiliations/stanford-ai-lab.jpg" alt="Stanford Artificial Intelligence Laboratory" height="28" valign="middle"></a>
+  <a href="https://ai.stanford.edu/"><img src="https://raw.githubusercontent.com/OpenWAM/OpenWAM/main/docs/assets/affiliations/stanford-ai-lab.jpg" alt="Stanford Artificial Intelligence Laboratory" height="28" valign="middle"></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://svl.stanford.edu/"><img src="docs/assets/affiliations/stanford-svl.png" alt="Stanford Vision and Learning Lab" height="28" valign="middle"></a>
+  <a href="https://svl.stanford.edu/"><img src="https://raw.githubusercontent.com/OpenWAM/OpenWAM/main/docs/assets/affiliations/stanford-svl.png" alt="Stanford Vision and Learning Lab" height="28" valign="middle"></a>
 </p>
 
 OpenWAM separates model topology, video/action conditioning, sequence
@@ -38,19 +38,19 @@ share the same trainer and visual stack.
 > **Release status:** OpenWAM 0.1.0 is pre-release Linux research software.
 > The public CPU lifecycle and synthetic artifacts are self-contained. Large
 > benchmark runs use separately provisioned datasets and checkpoints described
-> by the [artifact contract](docs/artifacts.md).
+> by the [artifact contract](https://github.com/OpenWAM/OpenWAM/blob/main/docs/artifacts.md).
 
 ## Upcoming Research Release
 
 Detailed evaluation results, trained model checkpoints, datasets, and the
 OpenWAM research paper are being prepared for public release and will be
 available very soon. Canonical links and integrity metadata will be added to
-the [artifact documentation](docs/artifacts.md) as each resource is published.
+the [artifact documentation](https://github.com/OpenWAM/OpenWAM/blob/main/docs/artifacts.md) as each resource is published.
 
 ## Research Scope
 
 For OpenWAM video pretraining, see the
-[pretraining datasets and workflow](docs/pretraining/index.md). The guide covers
+[pretraining datasets and workflow](https://github.com/OpenWAM/OpenWAM/blob/main/docs/pretraining/index.md). The guide covers
 the nine pretraining data sources, downloads, RGB multi-view composition before
 VAE encoding, task text, verified object storage with a bounded cache, training,
 checkpoints, and inference. These inputs are the pretraining corpus; downstream
@@ -113,7 +113,7 @@ uv run --extra train openwam-sanity \
 This path requires no private data, checkpoint, GPU, or external simulator. It
 checks config loading, dataset construction, a train forward pass, batch
 inference, and recurrent rollout-style inference. The
-[complete CPU first run](docs/quickstart.md#complete-cpu-first-run) adds exact
+[complete CPU first run](https://github.com/OpenWAM/OpenWAM/blob/main/docs/quickstart.md#complete-cpu-first-run) adds exact
 resume and checkpoint-backed evaluation.
 
 Install only the runtime needed for later work:
@@ -127,7 +127,7 @@ Install only the runtime needed for later work:
 | Documentation | `uv sync --extra docs` |
 
 Benchmark extras supply dependency overlays, not upstream source trees. Follow
-[Benchmarks and Data](docs/benchmarks.md) before a real simulator run.
+[Benchmarks and Data](https://github.com/OpenWAM/OpenWAM/blob/main/docs/benchmarks.md) before a real simulator run.
 
 ## Training
 
@@ -146,7 +146,7 @@ elsewhere.
 
 All architectures use `openwam-train`. The shipped Parallel Stream and Dual
 Expert LIBERO policy programs use the same validated full-trajectory W64 recipe
-described in [Training and Inference](docs/running_experiments.md#libero-policy-planning-default).
+described in [Training and Inference](https://github.com/OpenWAM/OpenWAM/blob/main/docs/running_experiments.md#libero-policy-planning-default).
 The reference 30-layer configs are FSDP workloads characterized with four 48 GB GPUs:
 
 ```bash
@@ -195,7 +195,7 @@ invocation config.
 Conditional FDM/IDM uses the dynamics-routing data adapter. The maintained
 config mixes real demonstrations with encoded counterfactual train and
 validation roots; a real-demo-only ablation is also supported. Read the
-[data prerequisites](docs/running_experiments.md#data-prerequisites) before
+[data prerequisites](https://github.com/OpenWAM/OpenWAM/blob/main/docs/running_experiments.md#data-prerequisites) before
 selecting `forward_dynamics` or `inverse_dynamics`.
 
 ## Evaluation And Rollout
@@ -222,7 +222,7 @@ uv run --extra sim openwam-sim-rollout \
 Benchmark adapters translate observations and actions. Sequence, attention,
 cache, and denoising semantics remain owned by the selected policy. Maintained
 LIBERO and GJD commands are listed in
-[Training and Inference](docs/running_experiments.md).
+[Training and Inference](https://github.com/OpenWAM/OpenWAM/blob/main/docs/running_experiments.md).
 
 ## Architecture
 
@@ -241,8 +241,8 @@ ExperimentConfig -> VariantPipeline -> VisualTower -> PolicyVariant -> ActionDec
 | `ActionDecoder` | Final supervised outputs, masks, losses, metrics, and committed actions. |
 
 This boundary keeps the visual stack stable while experiments vary one owned
-contract at a time. See [Architecture](docs/architecture.md) and
-[Policy Architectures and Programs](docs/policy_architectures.md).
+contract at a time. See [Architecture](https://github.com/OpenWAM/OpenWAM/blob/main/docs/architecture.md) and
+[Policy Architectures and Programs](https://github.com/OpenWAM/OpenWAM/blob/main/docs/policy_architectures.md).
 
 ## Use OpenWAM With Your System
 
@@ -269,8 +269,8 @@ uv run --extra train openwam-train \
 ```
 
 Extensions import compatibility-managed contracts from the role-specific
-`open_wam.sdk` modules. See the [Extension SDK](docs/extension_sdk.md) and
-[cookbooks](docs/cookbooks/new_policy_architecture.md).
+`open_wam.sdk` modules. See the [Extension SDK](https://github.com/OpenWAM/OpenWAM/blob/main/docs/extension_sdk.md) and
+[cookbooks](https://github.com/OpenWAM/OpenWAM/blob/main/docs/cookbooks/new_policy_architecture.md).
 
 ## Reproducibility
 
@@ -288,8 +288,8 @@ Exact numerical claims use the locked dependency graph and documented
 hardware/software stack. A refactor near model execution must pass immutable
 training-step, recurrent-inference, cache-rollover, and full-state-resume
 characterization; expected values are not regenerated by the refactor. See
-[Reproducibility](docs/reproducibility.md),
-[Compatibility](docs/compatibility.md), and [Testing](docs/testing.md).
+[Reproducibility](https://github.com/OpenWAM/OpenWAM/blob/main/docs/reproducibility.md),
+[Compatibility](https://github.com/OpenWAM/OpenWAM/blob/main/docs/compatibility.md), and [Testing](https://github.com/OpenWAM/OpenWAM/blob/main/docs/testing.md).
 
 ## Repository Layout
 
@@ -306,26 +306,26 @@ notes/index/   generated public consortium metadata packaged at runtime
 
 | Topic | Guide |
 | --- | --- |
-| Install and first run | [Quickstart](docs/quickstart.md) |
-| Runtime ownership | [Architecture](docs/architecture.md) |
-| Architectures and programs | [Policy Architectures](docs/policy_architectures.md) |
-| Train, resume, evaluate, and roll out | [Training and Inference](docs/running_experiments.md) |
-| Dataset and simulator setup | [Benchmarks and Data](docs/benchmarks.md) |
-| Custom datasets, policies, decoders, and simulators | [Extension SDK](docs/extension_sdk.md) |
-| Checkpoints and manifests | [Artifacts](docs/artifacts.md) |
-| Test and parity tiers | [Testing](docs/testing.md) |
+| Install and first run | [Quickstart](https://github.com/OpenWAM/OpenWAM/blob/main/docs/quickstart.md) |
+| Runtime ownership | [Architecture](https://github.com/OpenWAM/OpenWAM/blob/main/docs/architecture.md) |
+| Architectures and programs | [Policy Architectures](https://github.com/OpenWAM/OpenWAM/blob/main/docs/policy_architectures.md) |
+| Train, resume, evaluate, and roll out | [Training and Inference](https://github.com/OpenWAM/OpenWAM/blob/main/docs/running_experiments.md) |
+| Dataset and simulator setup | [Benchmarks and Data](https://github.com/OpenWAM/OpenWAM/blob/main/docs/benchmarks.md) |
+| Custom datasets, policies, decoders, and simulators | [Extension SDK](https://github.com/OpenWAM/OpenWAM/blob/main/docs/extension_sdk.md) |
+| Checkpoints and manifests | [Artifacts](https://github.com/OpenWAM/OpenWAM/blob/main/docs/artifacts.md) |
+| Test and parity tiers | [Testing](https://github.com/OpenWAM/OpenWAM/blob/main/docs/testing.md) |
 
 ## Contributing
 
 Contributions should preserve the typed runtime boundary and add focused tests
-for every changed contract. Read [CONTRIBUTING.md](CONTRIBUTING.md), the
-[Code of Conduct](CODE_OF_CONDUCT.md), and the
-[Security Policy](SECURITY.md) before opening a pull request.
+for every changed contract. Read [CONTRIBUTING.md](https://github.com/OpenWAM/OpenWAM/blob/main/CONTRIBUTING.md), the
+[Code of Conduct](https://github.com/OpenWAM/OpenWAM/blob/main/CODE_OF_CONDUCT.md), and the
+[Security Policy](https://github.com/OpenWAM/OpenWAM/blob/main/SECURITY.md) before opening a pull request.
 
 ## Citation
 
 If OpenWAM supports your research, cite the software record in
-[`CITATION.cff`](CITATION.cff):
+[`CITATION.cff`](https://github.com/OpenWAM/OpenWAM/blob/main/CITATION.cff):
 
 ```bibtex
 @software{open_wam_2026,
@@ -339,15 +339,15 @@ If OpenWAM supports your research, cite the software record in
 
 ## License
 
-OpenWAM is released under the [GNU Affero General Public License v3.0](LICENSE)
-with the redistribution attribution described in [`NOTICE`](NOTICE). Covered
+OpenWAM is released under the [GNU Affero General Public License v3.0](https://github.com/OpenWAM/OpenWAM/blob/main/LICENSE)
+with the redistribution attribution described in [`NOTICE`](https://github.com/OpenWAM/OpenWAM/blob/main/NOTICE). Covered
 modified versions and network services must provide corresponding source, and
 redistributed copies must preserve the OpenWAM attribution notice. Academic
 work that uses OpenWAM should cite the software record in
-[`CITATION.cff`](CITATION.cff).
+[`CITATION.cff`](https://github.com/OpenWAM/OpenWAM/blob/main/CITATION.cff).
 
 Third-party components retain their own terms; the adapted LingBot-VA module
 is distributed under Apache License 2.0. Full attributions are listed in
-[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) and [`LICENSES/`](LICENSES/).
+[`THIRD_PARTY_NOTICES.md`](https://github.com/OpenWAM/OpenWAM/blob/main/THIRD_PARTY_NOTICES.md) and [`LICENSES/`](https://github.com/OpenWAM/OpenWAM/tree/main/LICENSES/).
 Stanford, SAIL, and SVL marks are not licensed under AGPL-3.0-only and remain
 the property of Stanford University.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,13 +3,47 @@
 This guide is the public first-run path. It does not require private datasets,
 private checkpoints, CUDA, or external simulators.
 
-OpenWAM supports Linux with Python 3.11 or 3.12. Install `uv` before using the
-commands below.
+OpenWAM supports Linux with Python 3.11 or 3.12.
 
 ## Install
 
+### Installed SDK
+
+Once the PyPI release is available, install the canonical package in a virtual
+environment. Until then, use the source checkout below or install a reviewed
+wheel from the release-checks workflow.
+
 ```bash
-uv sync --group dev --extra train --extra eval
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install 'openwam[train,eval]'
+openwam-sanity \
+  --cfg configs/examples/public_tiny_synthetic_contract.yaml \
+  --device cpu --max-batches 1 --rollout-steps 1
+```
+
+For an alpha version, request the exact version shown on the release page
+with `==<version>`. The distribution is named `openwam`; Python code uses
+`import open_wam`. The official `open-wam`, `openwam-sdk`, and `open-wam-sdk`
+installation aliases forward to the same implementation and extras.
+
+The base `pip install openwam` needs only PyYAML and supports config/metadata
+APIs and CLI help. Add `[train,pretrain]` for video data preparation and
+pretraining, or `[eval]` for offline model evaluation. Weights, datasets, and
+external simulator source trees remain separately provisioned.
+
+All `openwam-*` commands below also work in an installed environment: omit
+their `uv run` / `uv run --extra ...` prefix after installing the relevant
+extras. Packaged config references do not require cloning the repository.
+Use the frozen checkout path for exact dependency reproduction; an ordinary
+PyPI install resolves the declared dependency ranges, not `uv.lock`.
+
+### Source Checkout
+
+Install `uv` and run from a clone of the repository:
+
+```bash
+uv sync --frozen --group dev --extra train --extra eval
 ```
 
 This installs the CPU-capable development, training, and evaluation stack used

--- a/docs/release.md
+++ b/docs/release.md
@@ -37,6 +37,98 @@ python scripts/check_release_metadata.py --dist-dir dist
 python -m twine check dist/*
 ```
 
+## PyPI SDK And Installation Aliases
+
+`openwam` is the canonical distribution; `open_wam` is the Python import.
+The official `open-wam`, `openwam-sdk`, and `open-wam-sdk` metapackages install
+the exact same version of `openwam`. Each forwards every canonical extra,
+including `[train]`, `[eval]`, and `[pretrain]`. They contain no Python modules
+or console scripts, so installing them together or uninstalling an alias
+does not overwrite or remove the implementation.
+
+PyPI normalizes underscores and periods to hyphens: `open_wam` installs
+`open-wam`, not `openwam`. Prefer the canonical name in new documentation and
+requirements. These are functional installation aliases, not empty name
+reservations. Account registration, TestPyPI publication, and pending Trusted
+Publishers do not reserve names on the production index.
+
+The first PyPI publication is a separate release operation; merging the
+packaging workflow does not mean the packages are already available. Build
+and exercise the release locally before publishing:
+
+```bash
+python -m pip install 'build>=1.2,<2' 'twine>=6' 'tomli-w>=1,<2' PyYAML pytest packaging
+python scripts/build_pypi_distributions.py --out-dir dist
+python scripts/check_release_metadata.py --dist-dir dist/core
+python scripts/check_release_metadata.py --dist-dir dist/aliases
+python -m twine check --strict dist/core/* dist/aliases/*
+python -m pip download --only-binary=:all: --dest dist/dependencies dist/core/*.whl
+OPENWAM_DISTRIBUTIONS_DIR="$PWD/dist" python -m pytest -q tests/test_pypi_distributions.py
+```
+
+Use a fresh output directory. The builder reads version, extras, and shared
+metadata from `pyproject.toml`; alias definitions do not duplicate dependency
+lists. Each wheel is built from its source distribution. Installation tests
+use isolated environments outside the checkout, check all four spellings and
+co-installation, inspect every extra, and exercise all installed CLI parsers.
+They do not establish GPU parity for a newly resolved dependency stack.
+
+### Publisher Setup
+
+On PyPI, verify the maintainer account's email, enable 2FA, and configure four
+pending GitHub Trusted Publishers under **Account > Publishing**:
+
+| Field | Value |
+| --- | --- |
+| Project | One entry each for `openwam`, `open-wam`, `openwam-sdk`, `open-wam-sdk` |
+| Owner | `OpenWAM` |
+| Repository | `OpenWAM` |
+| Workflow filename | `publish-pypi.yml` |
+| Environment | `pypi` |
+
+Repeat on TestPyPI, using its separate account and environment `testpypi`.
+For existing projects, add publishers in their project settings instead.
+Add a trusted backup project Owner after the first publication. No PyPI API
+token or password is stored in GitHub: publishing uses OIDC.
+
+Before enabling publication, create the `pypi` and `testpypi` GitHub
+environments in `OpenWAM/OpenWAM`, require maintainer approval, and restrict
+deployments to `v*` tags. GitHub environment protections are repository
+settings, not created by the workflow YAML. Protect version tags against
+replacement and deletion. See [PyPI's publisher setup](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/).
+
+### Release Procedure
+
+1. Merge and validate the public changes. Set the intended new version in
+   `pyproject.toml`, update `CITATION.cff`, `CHANGELOG.md`, and the attribution
+   version in `NOTICE` and its release check together. Use a PEP 440 suffix
+   such as `0.2.0a1` for an alpha; a GitHub prerelease flag alone does not mark
+   a PyPI version as a prerelease. Do not reuse the existing `v0.1.0` tag for
+   newer code. Date the release metadata when actually preparing the release.
+2. Run the release checklist, including the dependency audit. Review dependency
+   bounds and the supported Python/CUDA environment. `pip install` does not
+   apply `uv.lock`; exact model reproduction still uses the frozen checkout.
+   Do not waive security or numerical parity checks to obtain project names.
+3. Tag the reviewed production commit with `v<project.version>`. In Actions,
+   run **publish-pypi** against that tag with `index=testpypi`. The workflow
+   rejects staging/branch publication, checks tag/version agreement and main
+   ancestry, and runs the package and dependency gates before approval.
+4. Inspect the artifacts and approve the TestPyPI environment. Install the
+   candidate using TestPyPI **only** for the four OpenWAM distributions;
+   provision third-party dependencies from the normal index separately. Avoid
+   mixing indexes with `--extra-index-url` when verifying package provenance.
+5. Run the same tag with `index=pypi` and approve production publication.
+   The upload job has no checkout or build step: it uploads the artifacts
+   tested in that workflow run, canonical package first and then aliases.
+6. Verify all four project pages, versions, extras, and fresh installs. Record
+   the release and supported environment in the public documentation.
+
+Uploads to four projects are not atomic. If interrupted, rerun the same tag;
+existing files are skipped so the remaining uploads can finish. Do not move
+the tag or silently replace a bad release: inspect published files and use a
+new version for corrections. Publication only starts on manual dispatch;
+neither a main push nor a tag push uploads anything by itself.
+
 ## Distribution Resources
 
 The wheel includes the package plus read-only canonical configs, examples,

--- a/scripts/build_pypi_distributions.py
+++ b/scripts/build_pypi_distributions.py
@@ -1,0 +1,108 @@
+"""Build the canonical SDK and metadata-only installation aliases."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+import tomllib
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALLATION_ALIASES = ("open-wam", "openwam-sdk", "open-wam-sdk")
+
+
+def alias_pyproject(pyproject: dict[str, Any], name: str) -> dict[str, Any]:
+    """Forward the canonical version and every extra without shipping modules."""
+    canonical = pyproject["project"]
+    requirement = f"{canonical['name']}=={canonical['version']}"
+    project = {
+        key: canonical[key]
+        for key in ("version", "requires-python", "license", "authors", "urls", "classifiers")
+    }
+    project.update(
+        name=name,
+        description=f"Official installation alias for {canonical['name']}; use import open_wam.",
+        readme="README.md",
+        dependencies=[requirement],
+    )
+    project["license-files"] = ["LICENSE", "NOTICE"]
+    project["optional-dependencies"] = {
+        extra: [f"{canonical['name']}[{extra}]=={canonical['version']}"]
+        for extra in canonical.get("optional-dependencies", {})
+    }
+    return {
+        "build-system": pyproject["build-system"],
+        "project": project,
+        "tool": {"hatch": {"build": {"targets": {
+            "wheel": {"bypass-selection": True},
+            "sdist": {"only-include": ["pyproject.toml", "README.md", "LICENSE", "NOTICE"]},
+        }}}},
+    }
+
+
+def validate_release_tag(ref: str, version: str) -> None:
+    if ref != f"refs/tags/v{version}":
+        raise ValueError(f"Publishing requires refs/tags/v{version}, got {ref!r}.")
+
+
+def build_distributions(out_dir: Path) -> None:
+    import tomli_w
+
+    out_dir = out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if any(out_dir.iterdir()):
+        raise ValueError(f"Build output must be empty: {out_dir}")
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    def build(source: Path, destination: Path) -> None:
+        # The build frontend builds each wheel from its sdist, not the checkout.
+        subprocess.run(
+            [sys.executable, "-m", "build", "--outdir", str(destination), str(source)],
+            check=True,
+        )
+
+    build(REPO_ROOT, out_dir / "core")
+    with TemporaryDirectory(prefix="openwam-aliases-") as temporary:
+        for name in INSTALLATION_ALIASES:
+            source = Path(temporary) / name
+            source.mkdir()
+            (source / "pyproject.toml").write_text(
+                tomli_w.dumps(alias_pyproject(pyproject, name)), encoding="utf-8"
+            )
+            (source / "README.md").write_text(
+                f"# {name}\n\n"
+                "Official installation alias for [OpenWAM](https://pypi.org/project/openwam/).\n\n"
+                "This metapackage installs the matching OpenWAM release and forwards its\n"
+                "optional extras. It contains no Python modules or separate implementation.\n"
+                "Prefer `pip install openwam` for new environments; all installation names\n"
+                "use the same `import open_wam` and `openwam-*` commands.\n\n"
+                f"For example, `pip install '{name}[train,eval]'` installs the same runtime\n"
+                "as `pip install 'openwam[train,eval]'`. All aliases can coexist.\n\n"
+                "[Documentation](https://openwam.github.io/OpenWAM/) | "
+                "[Source](https://github.com/OpenWAM/OpenWAM)\n",
+                encoding="utf-8",
+            )
+            for notice in ("LICENSE", "NOTICE"):
+                shutil.copyfile(REPO_ROOT / notice, source / notice)
+            build(source, out_dir / "aliases")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, default=Path("dist"))
+    parser.add_argument("--check-tag", help="Validate a refs/tags/vVERSION ref without building.")
+    args = parser.parse_args(argv)
+    if args.check_tag is not None:
+        project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        validate_release_tag(args.check_tag, project["project"]["version"])
+    else:
+        build_distributions(args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pypi_distributions.py
+++ b/tests/test_pypi_distributions.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from email.parser import BytesParser
+import os
+from pathlib import Path
+import subprocess
+import tomllib
+import venv
+import zipfile
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+import pytest
+import yaml
+
+from scripts.build_pypi_distributions import (
+    INSTALLATION_ALIASES,
+    alias_pyproject,
+    validate_release_tag,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+PROJECT = PYPROJECT["project"]
+
+
+@pytest.mark.unit
+def test_installation_names_are_distinct_and_cover_requested_spellings() -> None:
+    assert {canonicalize_name(name) for name in (
+        "openwam", "open_wam", "openwam_sdk", "open_wam_sdk"
+    )} == {PROJECT["name"], *INSTALLATION_ALIASES}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", INSTALLATION_ALIASES)
+def test_alias_metadata_tracks_canonical_version_and_extras(name: str) -> None:
+    original = deepcopy(PYPROJECT)
+    project = alias_pyproject(PYPROJECT, name)["project"]
+    assert project["name"] == name
+    for key in ("version", "requires-python", "license", "authors", "urls", "classifiers"):
+        assert project[key] == PROJECT[key]
+    assert project["dependencies"] == [f"openwam=={PROJECT['version']}"]
+    assert project["optional-dependencies"] == {
+        extra: [f"openwam[{extra}]=={PROJECT['version']}"]
+        for extra in PROJECT["optional-dependencies"]
+    }
+    assert "scripts" not in project
+    assert PYPROJECT == original
+
+
+@pytest.mark.unit
+def test_aliases_follow_future_release_versions_and_new_extras() -> None:
+    pyproject = deepcopy(PYPROJECT)
+    pyproject["project"]["version"] = "0.2.0a1"
+    pyproject["project"]["optional-dependencies"]["new-runtime"] = ["example>=1"]
+    project = alias_pyproject(pyproject, "openwam-sdk")["project"]
+    assert project["dependencies"] == ["openwam==0.2.0a1"]
+    assert project["optional-dependencies"]["new-runtime"] == ["openwam[new-runtime]==0.2.0a1"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ref", ("refs/heads/main", "refs/tags/v9.9.9", "v0.1.0", ""))
+def test_publishing_rejects_nonmatching_release_refs(ref: str) -> None:
+    with pytest.raises(ValueError, match="Publishing requires"):
+        validate_release_tag(ref, PROJECT["version"])
+
+
+@pytest.mark.unit
+def test_publishing_accepts_matching_alpha_tag() -> None:
+    validate_release_tag("refs/tags/v0.2.0a1", "0.2.0a1")
+
+
+@pytest.mark.unit
+def test_publishing_is_manual_production_only_and_separated_from_builds() -> None:
+    workflow = yaml.load(
+        (REPO_ROOT / ".github/workflows/publish-pypi.yml").read_text(), Loader=yaml.BaseLoader
+    )
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    assert workflow["permissions"] == {"contents": "read"}
+    jobs = workflow["jobs"]
+    assert "github.repository == 'OpenWAM/OpenWAM'" in jobs["verify-ref"]["if"]
+    assert "refs/tags/v" in jobs["verify-ref"]["if"]
+    assert "git merge-base --is-ancestor HEAD origin/main" in str(jobs["verify-ref"])
+    assert "--check-tag" in str(jobs["verify-ref"])
+    assert jobs["checks"]["needs"] == "verify-ref"
+    assert jobs["checks"]["uses"] == "./.github/workflows/release-checks.yml"
+    assert jobs["checks"]["with"]["release"] == "true"
+    publish = jobs["publish"]
+    assert publish["needs"] == "checks"
+    assert publish["environment"]["name"] == "${{ inputs.index }}"
+    assert publish["permissions"] == {"id-token": "write"}
+    assert all("checkout" not in step.get("uses", "") for step in publish["steps"])
+    uploads = [step for step in publish["steps"] if "pypi-publish" in step.get("uses", "")]
+    assert [step["with"]["packages-dir"] for step in uploads] == ["dist/core/", "dist/aliases/"]
+    assert all(step["with"]["skip-existing"] == "true" for step in uploads)
+
+
+@pytest.mark.unit
+def test_release_checks_keep_dependency_audit_and_exercise_built_aliases() -> None:
+    workflow = yaml.load(
+        (REPO_ROOT / ".github/workflows/release-checks.yml").read_text(), Loader=yaml.BaseLoader
+    )
+    assert "workflow_call" in workflow["on"]
+    assert "pull_request" in workflow["on"]
+    assert "check_dependency_audit.py" in str(workflow["jobs"]["dependency-audit"])
+    package = workflow["jobs"]["package"]
+    assert "build_pypi_distributions.py" in str(package)
+    assert "test_pypi_distributions.py" in str(package)
+    assert "OPENWAM_DISTRIBUTIONS_DIR" in str(package)
+
+
+@pytest.fixture(scope="module")
+def distributions() -> Path:
+    root = os.environ.get("OPENWAM_DISTRIBUTIONS_DIR")
+    if not root:
+        pytest.skip("Set OPENWAM_DISTRIBUTIONS_DIR to exercise built release artifacts.")
+    path = Path(root).resolve()
+    assert path.is_dir()
+    return path
+
+
+@pytest.mark.integration
+def test_built_alias_wheels_are_metadata_only_and_forward_all_extras(distributions: Path) -> None:
+    assert len(list((distributions / "core").glob("*.whl"))) == 1
+    assert len(list((distributions / "core").glob("*.tar.gz"))) == 1
+    assert len(list((distributions / "aliases").glob("*.tar.gz"))) == len(INSTALLATION_ALIASES)
+    wheels = list((distributions / "aliases").glob("*.whl"))
+    assert len(wheels) == len(INSTALLATION_ALIASES)
+    observed = set()
+    for wheel in wheels:
+        with zipfile.ZipFile(wheel) as archive:
+            members = archive.namelist()
+            metadata_name, = [name for name in members if name.endswith(".dist-info/METADATA")]
+            prefix = metadata_name.removesuffix("METADATA")
+            assert all(name.startswith(prefix) for name in members)
+            assert not any(name.endswith("entry_points.txt") for name in members)
+            metadata = BytesParser().parsebytes(archive.read(metadata_name))
+        name = canonicalize_name(metadata["Name"])
+        assert name in INSTALLATION_ALIASES
+        observed.add(name)
+        assert metadata["Version"] == PROJECT["version"]
+        assert SpecifierSet(metadata["Requires-Python"]) == SpecifierSet(PROJECT["requires-python"])
+        assert metadata["License-Expression"] == PROJECT["license"]
+        assert set(metadata.get_all("License-File")) == {"LICENSE", "NOTICE"}
+        assert set(metadata.get_all("Provides-Extra")) == set(PROJECT["optional-dependencies"])
+        requirements = [Requirement(value) for value in metadata.get_all("Requires-Dist")]
+        assert len(requirements) == 1 + len(PROJECT["optional-dependencies"])
+        for requirement in requirements:
+            assert requirement.name == PROJECT["name"]
+            assert str(requirement.specifier) == f"=={PROJECT['version']}"
+        for extra in ("", *PROJECT["optional-dependencies"]):
+            active = [r for r in requirements if r.marker is None or r.marker.evaluate({"extra": extra})]
+            assert {frozenset(r.extras) for r in active} == (
+                {frozenset(), frozenset({extra})} if extra else {frozenset()}
+            )
+    assert observed == set(INSTALLATION_ALIASES)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("requested", (
+    ("openwam",), ("open_wam",), ("openwam_sdk",), ("open_wam_sdk",),
+    ("openwam", "open_wam", "openwam_sdk", "open_wam_sdk"),
+))
+def test_fresh_installs_share_one_implementation(
+    distributions: Path, tmp_path: Path, requested: tuple[str, ...]
+) -> None:
+    environment = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=True).create(environment)
+    python = environment / "bin/python"
+    command = [str(python), "-m", "pip", "install", "--no-index", "--only-binary=:all:"]
+    for directory in ("core", "aliases", "dependencies"):
+        command.extend(("--find-links", str(distributions / directory)))
+    subprocess.run(
+        [*command, *(f"{name}=={PROJECT['version']}" for name in requested)],
+        check=True, cwd=tmp_path,
+    )
+    subprocess.run([str(python), "-m", "pip", "check"], check=True, cwd=tmp_path)
+    subprocess.run([
+        str(python), "-I", "-c",
+        "import importlib.util, importlib.metadata as m, pathlib, sys; "
+        "import open_wam, open_wam.sdk.config, open_wam.sdk.results; "
+        "from open_wam.sdk.config import resolve_config_reference; "
+        "assert open_wam.__version__ == sys.argv[1]; "
+        "assert pathlib.Path(open_wam.__file__).is_relative_to(sys.prefix); "
+        "assert importlib.util.find_spec('torch') is None; "
+        "assert all(m.version(n) == sys.argv[1] for n in sys.argv[2:]); "
+        "assert resolve_config_reference('configs/examples/public_tiny_synthetic_contract.yaml').is_file()",
+        PROJECT["version"], *requested,
+    ], check=True, cwd=tmp_path)
+    for command in PROJECT["scripts"]:
+        subprocess.run([str(environment / "bin" / command), "--help"], check=True, cwd=tmp_path)
+    if len(requested) > 1:
+        subprocess.run(
+            [str(python), "-m", "pip", "uninstall", "-y", *INSTALLATION_ALIASES],
+            check=True, cwd=tmp_path,
+        )
+        subprocess.run(
+            [str(python), "-I", "-c", "import open_wam.sdk.config"], check=True, cwd=tmp_path
+        )


### PR DESCRIPTION
## Summary

Automated public projection of validated staging main.

## Change Snapshot

- **build: prepare PyPI SDK aliases and guarded publishing** ([staging PR 76](https://github.com/DaivdYuan/OpenWAM-staging/pull/76), `029a092c`)
  Prepare PyPI publication of the existing SDK as one implementation plus three official installation aliases, with guarded publishing and installation tests. Include condensed public change snapshots in production promotion PRs. Model and runtime semantics are unchanged; this does not upload a release.

Snapshot of staging changes; the public diff remains authoritative.

| Contract | Commit |
| --- | --- |
| Staging source | `029a092cdce955adb32fa84550f6bf6668df1b9e` |
| Production base | `806f3a4b8744615755e5919001d947f20dc31f3f` |
| Matching staging ancestor | `95a4d00e4f679adef89b4e0540ab516518877b7a` |
| Projected tree | `375ac174965f6fa632235a15e1123076bc0b6d95` |

The projection removes only declared private paths and performs no
content rewriting. This PR changes 8 public paths;
the Files changed tab is the complete projected diff. Do not edit this
automation branch directly; make corrections in staging instead.

Production review and required checks remain authoritative. Promotion
never merges automatically.
