### PR TITLE
Promote validated OpenWAM staging changes

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,6 +12,16 @@ on:
         options:
           - testpypi
           - pypi
+      project:
+        description: Publish one project (publish openwam before its aliases)
+        required: true
+        type: choice
+        default: openwam
+        options:
+          - openwam
+          - open-wam
+          - openwam-sdk
+          - open-wam-sdk
 
 permissions:
   contents: read
@@ -48,9 +58,9 @@ jobs:
   publish:
     needs: checks
     runs-on: ubuntu-latest
-    # Configure required reviewers and v* tag restrictions on both environments.
+    # Pending PyPI projects need distinct identities; protect each environment.
     environment:
-      name: ${{ inputs.index }}
+      name: ${{ inputs.project == 'openwam' && inputs.index || format('{0}-{1}', inputs.index, inputs.project) }}
     permissions:
       id-token: write
     steps:
@@ -58,15 +68,32 @@ jobs:
         with:
           name: pypi-distributions
           path: dist
-      - name: Publish canonical OpenWAM first
+      - name: Select the reviewed project distributions
+        env:
+          RELEASE_PROJECT: ${{ inputs.project }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$RELEASE_PROJECT" in
+            openwam) directory=dist/core ;;
+            open-wam|openwam-sdk|open-wam-sdk) directory=dist/aliases ;;
+            *) echo "Unsupported release project" >&2; exit 1 ;;
+          esac
+          name="${RELEASE_PROJECT//-/_}"
+          version="${RELEASE_TAG#v}"
+          shopt -s nullglob
+          wheels=("$directory/$name-$version-"*.whl)
+          sdist="$directory/$name-$version.tar.gz"
+          if [[ ${#wheels[@]} -ne 1 || ! -f "$sdist" ]]; then
+            echo "Expected one wheel and source archive for $RELEASE_PROJECT $version" >&2
+            exit 1
+          fi
+          mkdir upload
+          cp -- "${wheels[0]}" "$sdist" upload/
+      - name: Publish selected project
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: ${{ inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
-          packages-dir: dist/core/
-          skip-existing: true
-      - name: Publish official installation aliases
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
-        with:
-          repository-url: ${{ inputs.index == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
-          packages-dir: dist/aliases/
+          packages-dir: upload/
           skip-existing: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -75,24 +75,34 @@ They do not establish GPU parity for a newly resolved dependency stack.
 
 ### Publisher Setup
 
-On PyPI, verify the maintainer account's email, enable 2FA, and configure four
-pending GitHub Trusted Publishers under **Account > Publishing**:
+On PyPI, verify the maintainer account's email, enable 2FA, and configure
+pending GitHub Trusted Publishers under **Account > Publishing**. Use owner
+`OpenWAM`, repository `OpenWAM`, and workflow filename `publish-pypi.yml` for
+each project, with distinct environments:
 
-| Field | Value |
-| --- | --- |
-| Project | One entry each for `openwam`, `open-wam`, `openwam-sdk`, `open-wam-sdk` |
-| Owner | `OpenWAM` |
-| Repository | `OpenWAM` |
-| Workflow filename | `publish-pypi.yml` |
-| Environment | `pypi` |
+| Project / workflow `project` input | PyPI environment | TestPyPI environment |
+| --- | --- | --- |
+| `openwam` | `pypi` | `testpypi` |
+| `open-wam` | `pypi-open-wam` | `testpypi-open-wam` |
+| `openwam-sdk` | `pypi-openwam-sdk` | `testpypi-openwam-sdk` |
+| `open-wam-sdk` | `pypi-open-wam-sdk` | `testpypi-open-wam-sdk` |
 
-Repeat on TestPyPI, using its separate account and environment `testpypi`.
+PyPI rejects identical pending-publisher identities across project names and
+allows at most three pending publishers per account at once. Register and
+publish `openwam` first, then register the remaining aliases as slots become
+available. Publishing only `openwam` and `open-wam` is supported; unselected
+projects require no publisher or GitHub environment. An existing `OpenWAM`
+entry already covers `openwam`; scope its environment to `pypi`, not `(Any)`.
+These pending-publisher restrictions are enforced by
+[PyPI's registration handler](https://github.com/pypi/warehouse/blob/main/warehouse/accounts/views.py).
+
+Repeat on TestPyPI using its separate account and the environments above.
 For existing projects, add publishers in their project settings instead.
 Add a trusted backup project Owner after the first publication. No PyPI API
 token or password is stored in GitHub: publishing uses OIDC.
 
-Before enabling publication, create the `pypi` and `testpypi` GitHub
-environments in `OpenWAM/OpenWAM`, require maintainer approval, and restrict
+Before publishing a selected project, create its matching GitHub
+environment in `OpenWAM/OpenWAM`, require maintainer approval, and restrict
 deployments to `v*` tags. GitHub environment protections are repository
 settings, not created by the workflow YAML. Protect version tags against
 replacement and deletion. See [PyPI's publisher setup](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/).
@@ -110,21 +120,27 @@ replacement and deletion. See [PyPI's publisher setup](https://docs.pypi.org/tru
    apply `uv.lock`; exact model reproduction still uses the frozen checkout.
    Do not waive security or numerical parity checks to obtain project names.
 3. Tag the reviewed production commit with `v<project.version>`. In Actions,
-   run **publish-pypi** against that tag with `index=testpypi`. The workflow
-   rejects staging/branch publication, checks tag/version agreement and main
+   run **publish-pypi** against that tag with `index=testpypi`, `project=openwam`.
+   The workflow rejects staging/branch publication, checks tag/version agreement and main
    ancestry, and runs the package and dependency gates before approval.
-4. Inspect the artifacts and approve the TestPyPI environment. Install the
-   candidate using TestPyPI **only** for the four OpenWAM distributions;
+4. Inspect the artifacts and approve the matching TestPyPI environment. Once
+   `openwam` succeeds, dispatch again for each desired alias, using the same
+   tag and index with its `project` value. Install the candidate using
+   TestPyPI **only** for the selected OpenWAM distributions;
    provision third-party dependencies from the normal index separately. Avoid
    mixing indexes with `--extra-index-url` when verifying package provenance.
-5. Run the same tag with `index=pypi` and approve production publication.
-   The upload job has no checkout or build step: it uploads the artifacts
-   tested in that workflow run, canonical package first and then aliases.
-6. Verify all four project pages, versions, extras, and fresh installs. Record
+5. Run the same tag with `index=pypi`, `project=openwam`, and approve production
+   publication. Wait for success before dispatching each desired alias. The
+   upload job has no checkout or build step: it selects only the requested
+   project's wheel and source archive from the tested artifacts. Building and
+   testing all aliases does not publish them.
+6. Verify the selected project pages, versions, extras, and fresh installs. Record
    the release and supported environment in the public documentation.
 
-Uploads to four projects are not atomic. If interrupted, rerun the same tag;
-existing files are skipped so the remaining uploads can finish. Do not move
+Each dispatch publishes one project. To start with the two installation spellings,
+publish `project=openwam`, then `project=open-wam`; SDK aliases can wait.
+If interrupted, rerun the same project, index, and tag; existing files are
+skipped so the remaining uploads can finish. Do not move
 the tag or silently replace a bad release: inspect published files and use a
 new version for corrections. Publication only starts on manual dispatch;
 neither a main push nor a tag push uploads anything by itself.

--- a/tests/test_pypi_distributions.py
+++ b/tests/test_pypi_distributions.py
@@ -25,6 +25,9 @@ from scripts.build_pypi_distributions import (
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 PROJECT = PYPROJECT["project"]
+PUBLISH_WORKFLOW = yaml.load(
+    (REPO_ROOT / ".github/workflows/publish-pypi.yml").read_text(), Loader=yaml.BaseLoader
+)
 
 
 @pytest.mark.unit
@@ -75,9 +78,7 @@ def test_publishing_accepts_matching_alpha_tag() -> None:
 
 @pytest.mark.unit
 def test_publishing_is_manual_production_only_and_separated_from_builds() -> None:
-    workflow = yaml.load(
-        (REPO_ROOT / ".github/workflows/publish-pypi.yml").read_text(), Loader=yaml.BaseLoader
-    )
+    workflow = PUBLISH_WORKFLOW
     assert set(workflow["on"]) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"contents": "read"}
     jobs = workflow["jobs"]
@@ -90,12 +91,79 @@ def test_publishing_is_manual_production_only_and_separated_from_builds() -> Non
     assert jobs["checks"]["with"]["release"] == "true"
     publish = jobs["publish"]
     assert publish["needs"] == "checks"
-    assert publish["environment"]["name"] == "${{ inputs.index }}"
+    project = workflow["on"]["workflow_dispatch"]["inputs"]["project"]
+    assert project["type"] == "choice"
+    assert project["default"] == PROJECT["name"]
+    assert project["options"] == [PROJECT["name"], *INSTALLATION_ALIASES]
+    assert publish["environment"]["name"] == (
+        "${{ inputs.project == 'openwam' && inputs.index || "
+        "format('{0}-{1}', inputs.index, inputs.project) }}"
+    )
     assert publish["permissions"] == {"id-token": "write"}
     assert all("checkout" not in step.get("uses", "") for step in publish["steps"])
     uploads = [step for step in publish["steps"] if "pypi-publish" in step.get("uses", "")]
-    assert [step["with"]["packages-dir"] for step in uploads] == ["dist/core/", "dist/aliases/"]
+    assert [step["with"]["packages-dir"] for step in uploads] == ["upload/"]
     assert all(step["with"]["skip-existing"] == "true" for step in uploads)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", (PROJECT["name"], *INSTALLATION_ALIASES))
+@pytest.mark.parametrize("version", (PROJECT["version"], "0.2.0a1"))
+def test_publishing_selects_only_requested_project_and_tag(
+    tmp_path: Path, name: str, version: str,
+) -> None:
+    expected = {}
+    for project in (PROJECT["name"], *INSTALLATION_ALIASES):
+        directory = tmp_path / "dist" / ("core" if project == PROJECT["name"] else "aliases")
+        directory.mkdir(parents=True, exist_ok=True)
+        for candidate in (version, "9.9.9"):
+            for suffix in ("-py3-none-any.whl", ".tar.gz"):
+                filename = f"{project.replace('-', '_')}-{candidate}{suffix}"
+                payload = filename.encode()
+                (directory / filename).write_bytes(payload)
+                if project == name and candidate == version:
+                    expected[filename] = payload
+    selection, = [step for step in PUBLISH_WORKFLOW["jobs"]["publish"]["steps"] if "run" in step]
+    assert selection["env"] == {
+        "RELEASE_PROJECT": "${{ inputs.project }}", "RELEASE_TAG": "${{ github.ref_name }}",
+    }
+    subprocess.run(
+        ["bash", "-c", selection["run"]], cwd=tmp_path, check=True,
+        env={**os.environ, "RELEASE_PROJECT": name, "RELEASE_TAG": f"v{version}"},
+    )
+    assert {path.name: path.read_bytes() for path in (tmp_path / "upload").iterdir()} == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failure", (
+    "unknown_project", "missing_wheel", "missing_sdist", "multiple_wheels", "existing_upload",
+))
+def test_publishing_refuses_incomplete_or_ambiguous_payloads(tmp_path: Path, failure: str) -> None:
+    directory = tmp_path / "dist/aliases"
+    directory.mkdir(parents=True)
+    wheel = directory / "open_wam-1.2.3-py3-none-any.whl"
+    sdist = directory / "open_wam-1.2.3.tar.gz"
+    wheel.touch()
+    sdist.touch()
+    if failure == "missing_wheel":
+        wheel.unlink()
+    elif failure == "missing_sdist":
+        sdist.unlink()
+    elif failure == "multiple_wheels":
+        (directory / "open_wam-1.2.3-py2.py3-none-any.whl").touch()
+    elif failure == "existing_upload":
+        (tmp_path / "upload").mkdir()
+        (tmp_path / "upload/unrelated.whl").touch()
+    selection, = [step for step in PUBLISH_WORKFLOW["jobs"]["publish"]["steps"] if "run" in step]
+    result = subprocess.run(
+        ["bash", "-c", selection["run"]], cwd=tmp_path, capture_output=True,
+        env={
+            **os.environ, "RELEASE_TAG": "v1.2.3",
+            "RELEASE_PROJECT": "unknown" if failure == "unknown_project" else "open-wam",
+        },
+    )
+    assert result.returncode != 0
+    assert not (tmp_path / "upload" / wheel.name).exists()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Automated public projection of validated staging main.

## Change Snapshot

- **fix: publish PyPI projects with distinct trusted identities** ([staging PR 77](https://github.com/DaivdYuan/OpenWAM-staging/pull/77), `fad959b9`)
  Publish one selected SDK distribution per workflow dispatch, with a project-specific Trusted Publisher environment. This supports releasing openwam and its open-wam installation alias first without requiring SDK-alias registrations. Package implementation and runtime semantics are unchanged.

Snapshot of staging changes; the public diff remains authoritative.

| Contract | Commit |
| --- | --- |
| Staging source | `fad959b996a13bcb09670c7a9104785c453a1e71` |
| Production base | `11a81d0d563b5efe1bd63fd9299c2235f09435bc` |
| Matching staging ancestor | `029a092cdce955adb32fa84550f6bf6668df1b9e` |
| Projected tree | `a400f1611c3b530b7bd8f813ca375a496617489f` |

The projection removes only declared private paths and performs no
content rewriting. This PR changes 3 public paths;
the Files changed tab is the complete projected diff. Do not edit this
automation branch directly; make corrections in staging instead.

Production review and required checks remain authoritative. Promotion
never merges automatically.
