### PR TITLE
Promote validated OpenWAM staging changes

### DIFF
--- a/.github/dependency-audit-exceptions.toml
+++ b/.github/dependency-audit-exceptions.toml
@@ -1,6 +1,13 @@
 schema_version = 1
 
 [[exceptions]]
+id = "CVE-2026-69112"
+package = "accelerate"
+version = "1.13.0"
+expires = 2026-10-09
+reason = "Maintainer-authorized risk acceptance for the 0.1.1 SDK release, not a vulnerability fix. A malicious checkpoint shard index can escape its directory or reference a special file. Only owner-reviewed checkpoints in trusted, non-writable-by-others directories are supported under this exception; safetensors alone is insufficient. Upstream closed the report as outside its artifact-trust threat model without a released fix (huggingface/accelerate#4067, #4214). Keep the characterized dependency version and reassess before expiry; the base SDK does not install Accelerate."
+
+[[exceptions]]
 id = "PYSEC-2026-40"
 package = "diffusers"
 version = "0.37.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 OpenWAM follows semantic-versioned public surfaces for configs, CLI flags,
 result schemas, artifact manifests, and checkpoint layout expectations.
 
+## 0.1.1 - 2026-09-09
+
+### Added
+
+- PyPI release tooling for the `openwam` SDK and exact-version installation
+  aliases, with isolated installation tests and project-scoped Trusted
+  Publishers. The initial publication targets `openwam` and `open-wam`.
+- Condensed public change snapshots in staging-to-production promotion PRs.
+
+### Security
+
+- Documented, maintainer-authorized acceptance of the malicious-checkpoint
+  risk in `accelerate==1.13.0` / `CVE-2026-69112`, expiring 2026-10-09.
+  This is not a vulnerability fix; see [Artifact Trust](SECURITY.md#artifact-trust).
+  The dependency audit remains enforced, and the base SDK does not install
+  Accelerate. Model code and third-party dependency versions are unchanged.
+
 ## 0.1.0 - 2026-09-07
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use OpenWAM in research, please cite this software record."
 title: "OpenWAM"
-version: "0.1.0"
-date-released: "2026-09-07"
+version: "0.1.1"
+date-released: "2026-09-09"
 authors:
   - name: "OpenWAM Team"
 repository-code: "https://github.com/OpenWAM/OpenWAM"

--- a/NOTICE
+++ b/NOTICE
@@ -16,7 +16,7 @@ authorship, attribution, or legal notices.
 
 Required software attribution:
 
-    OpenWAM Team, Stanford Vision and Learning Lab (SVL), Stanford University. OpenWAM, version 0.1.0, 2026.
+    OpenWAM Team, Stanford Vision and Learning Lab (SVL), Stanford University. OpenWAM, version 0.1.1, 2026.
     https://github.com/OpenWAM/OpenWAM
 
 This requirement governs attribution distributed with the software. It does

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ OpenWAM separates model topology, video/action conditioning, sequence
 semantics, visual execution, and action decoding so that controlled experiments
 share the same trainer and visual stack.
 
-> **Release status:** OpenWAM 0.1.0 is pre-release Linux research software.
+> **Release status:** OpenWAM 0.1.1 is alpha-stage Linux research software.
 > The public CPU lifecycle and synthetic artifacts are self-contained. Large
 > benchmark runs use separately provisioned datasets and checkpoints described
 > by the [artifact contract](https://github.com/OpenWAM/OpenWAM/blob/main/docs/artifacts.md).
@@ -332,7 +332,7 @@ If OpenWAM supports your research, cite the software record in
   title   = {OpenWAM},
   author  = {{OpenWAM Team}},
   year    = {2026},
-  version = {0.1.0},
+  version = {0.1.1},
   url     = {https://github.com/OpenWAM/OpenWAM}
 }
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,21 @@ release checks. Narrow exceptions live in
 version, advisory, rationale, and expiration date. New, stale, or expired
 exceptions fail CI.
 
+For the 0.1.1 SDK release, maintainers accepted the residual risk from
+`accelerate==1.13.0` / `CVE-2026-69112` until **2026-10-09**. A malicious
+sharded-checkpoint index can reference files outside the checkpoint directory
+or special files that hang the loader. Safetensors does not prevent that path
+resolution issue. Only use checkpoints whose source and shard index have been
+reviewed, in directories not writable by other users; do not expose model
+loading as a service accepting untrusted uploads. This applies to optional
+model/training stacks, not the dependency-light base SDK.
+
+This exception is **risk acceptance, not a code fix**. The upstream maintainer
+[closed the report as outside their artifact-trust threat model](https://github.com/huggingface/accelerate/issues/4067#issuecomment-5586233400),
+but the advisory remains active. The frozen-version exception must be
+reassessed before expiry; it does not cover arbitrary versions resolved by
+installing optional PyPI extras.
+
 Out of scope:
 
 - expected failures from missing optional simulator packages

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,8 +9,8 @@ OpenWAM supports Linux with Python 3.11 or 3.12.
 
 ### Installed SDK
 
-Once the PyPI release is available, install the canonical package in a virtual
-environment. Until then, use the source checkout below or install a reviewed
+For a published release, install the canonical package in a virtual environment.
+For an unreleased revision, use the source checkout below or install a reviewed
 wheel from the release-checks workflow.
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openwam"
-version = "0.1.0"
+version = "0.1.1"
 description = "Extensible world-action-model training and evaluation with a LingBot-compatible visual core."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -78,7 +78,7 @@ REQUIRED_PROJECT_CLASSIFIERS = frozenset(
 REQUIRED_PROJECT_KEYWORDS = frozenset({"robotics", "world action models", "world models"})
 REQUIRED_ATTRIBUTION = (
     "OpenWAM Team, Stanford Vision and Learning Lab (SVL), Stanford University. "
-    "OpenWAM, version 0.1.0, 2026."
+    "OpenWAM, version 0.1.1, 2026."
 )
 _SHA256_PATTERN = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -4,7 +4,12 @@ from datetime import date
 
 import pytest
 
-from scripts.check_dependency_audit import AuditException, validate_audit_report
+from scripts.check_dependency_audit import (
+    DEFAULT_POLICY,
+    AuditException,
+    load_audit_exceptions,
+    validate_audit_report,
+)
 
 
 def _report(*, vulnerability_id: str = "PYSEC-test") -> dict[str, object]:
@@ -66,3 +71,27 @@ def test_dependency_audit_rejects_stale_exception() -> None:
             (_exception(),),
             today=date(2026, 8, 6),
         )
+
+
+@pytest.mark.parametrize("version,today,error", (
+    ("1.13.0", date(2026, 9, 9), None),
+    ("1.14.0", date(2026, 9, 9), "unaccepted vulnerabilities"),
+    ("1.13.0", date(2026, 10, 10), "expired"),
+))
+def test_accelerate_release_exception_is_version_and_time_bounded(
+    version: str, today: date, error: str | None,
+) -> None:
+    exception, = [
+        item for item in load_audit_exceptions(DEFAULT_POLICY)
+        if item.vulnerability_id == "CVE-2026-69112"
+    ]
+    report = {"dependencies": [{
+        "name": "accelerate", "version": version,
+        "vulns": [{"id": "CVE-2026-69112", "fix_versions": []}],
+    }]}
+    if error is not None:
+        with pytest.raises(ValueError, match=error):
+            validate_audit_report(report, (exception,), today=today)
+    else:
+        result = validate_audit_report(report, (exception,), today=today)
+        assert result.accepted_exceptions == (exception,)

--- a/uv.lock
+++ b/uv.lock
@@ -1406,7 +1406,7 @@ wheels = [
 
 [[package]]
 name = "openwam"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Automated public projection of validated staging main.

## Change Snapshot

- **build: release SDK 0.1.1 with bounded checkpoint-risk acceptance** ([staging PR 79](https://github.com/DaivdYuan/OpenWAM-staging/pull/79), `51fcc1d3`)
  Prepare OpenWAM 0.1.1 for PyPI publication with updated release metadata and a documented, maintainer-authorized exception for the Accelerate malicious-checkpoint advisory, expiring 2026-10-09. The audit remains enabled. This is risk acceptance, not a vulnerability fix; model implementation and third-party versions are unchanged.

Snapshot of staging changes; the public diff remains authoritative.

| Contract | Commit |
| --- | --- |
| Staging source | `51fcc1d3c485a4c11280a0563148b304cb2019b5` |
| Production base | `9580e1d7dce8daa6d77c9c539fa460a829875664` |
| Matching staging ancestor | `fad959b996a13bcb09670c7a9104785c453a1e71` |
| Projected tree | `0b666496797a718867a985cc8ec3842e0243db04` |

The projection removes only declared private paths and performs no
content rewriting. This PR changes 11 public paths;
the Files changed tab is the complete projected diff. Do not edit this
automation branch directly; make corrections in staging instead.

Production review and required checks remain authoritative. Promotion
never merges automatically.
